### PR TITLE
exec_command on RHEL6 doesn't have timeout

### DIFF
--- a/common/restraint.py
+++ b/common/restraint.py
@@ -56,7 +56,7 @@ class SSHClient(paramiko.SSHClient):
 		sys.exit(1)
 	    else:
 	        try:
-		     stdin, stdout, stderr = self.exec_command(args,timeout=30)
+		     stdin, stdout, stderr = self.exec_command(args)
 	   	except paramiko.SSHException, e:
 		     print "Cannot execute %s", args
 		else:


### PR DESCRIPTION
SSHClient.exec_command doesn't have timeout
its available python-paramiko-1.15.1-1 but not
in python-paramiko-1.7.5-2.1.el6.noarch
