### PR TITLE
Earlier it was mandatory to provider --build-repo option to restraint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Installing pre-requisities
 
 .. code-block:: bash
 
-   ]# yum install -y python-setuptools autoconf gcc python-devel tar
+   ]# yum install -y git python-setuptools autoconf gcc python-devel tar
 
    Download and install koji from
    http://koji.fedoraproject.org/koji/packageinfo?packageID=1181

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Installing pre-requisities
 
 .. code-block:: bash
 
-   ]# yum install -y python-setuptools autoconf gcc python-devel
+   ]# yum install -y python-setuptools autoconf gcc python-devel tar
 
    Download and install koji from
    http://koji.fedoraproject.org/koji/packageinfo?packageID=1181

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,18 @@ Installing pre-requisities
 
 .. code-block:: bash
 
+   ]# yum install -y python-setuptools autoconf gcc python-devel
+
+   Download and install koji from
+   http://koji.fedoraproject.org/koji/packageinfo?packageID=1181
+
    ]# git clone https://github.com/gsr-shanks/nexus.git
    ]# cd nexus
-   ]# python setup.py
+   ]# python setup.py install
+
+   ]# python nexus/utils/restraint_repo_finder.py
+
+   ]# yum install -y restraint restraint-client
 
 Alternately you can download the rpm version of nexus at
 https://mrniranjan.fedorapeople.org/

--- a/nexus/tasks/cli.py
+++ b/nexus/tasks/cli.py
@@ -54,7 +54,8 @@ def create_parser():
     parser_errata.add_argument('--show-triggers', help=argparse.SUPPRESS)
 
     parser_restraint = subparser.add_parser('restraint')
-    parser_restraint.add_argument('--build-repo', help='Build repo')
+    parser_restraint.add_argument('--build-repo', help='.repo file which you \
+                                    would like to copy to test resources')
     parser_restraint.add_argument('--restraint-xml', help='Restraint xml file')
     parser_restraint.add_argument('--show-triggers', help=argparse.SUPPRESS)
 

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,16 @@ setup(
     packages=find_packages(),
     scripts=['bin/nexus'],
     install_requires=[
-        'paramiko',
-        'ConfigParser',
-        'simplejson',
+        'pbr',
         'wget',
         'glob2',
-        'python-jenkins',
-	 'pbr'
+        'paramiko',
+        'argparse',
+        'requests',
+        'simplejson',
+        'ConfigParser',
+        'BeautifulSoup',
+        'python-jenkins'
     ],
     include_package_data=True
 )


### PR DESCRIPTION
subcommand as an option. With this patch it has become optional as the
script will move ahead since there are no repos to be copied.