### PR TITLE
restraint_junit and restraint_html are now part of restraint.py, hence

### DIFF
--- a/nexus/plugins/ci.py
+++ b/nexus/plugins/ci.py
@@ -34,14 +34,5 @@ class CI():
             """
             restraint.run_restraint(options, conf_dict)
 
-            """ This function converts job.xml to junit.xml for jenkins
-            trend.
-            """
-            restraint.restraint_junit()
-
-            """ This function copies index.html created by restraint within
-            its job directory to WORKSPACE.
-            """
-            restraint.restraint_html()
         else:
             logger.log.error("Unknown provisioner")


### PR DESCRIPTION
removing it from ci.py

Signed-off-by: Gowrishankar Rajaiyan <gsr@redhat.com>